### PR TITLE
feat: have typeorm use database url from configservice

### DIFF
--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 
 import { InventoryModule } from '../inventory/inventory.module';
 import { UserModule } from '../user/user.module';
@@ -24,19 +25,17 @@ import { PostSubscriptionModule } from '../post-subscription/post-subscription.m
 import { PostReadModule } from '../post-read/post-read.module';
 import { ReportsModule } from '../reports/reports.module';
 
-// When we set up the actual DB, we need to change this to read values from a file.
-// That way, we aren't leaking db credentials on our public git repo.
 @Module({
   imports: [
-    TypeOrmModule.forRoot({
-      type: 'postgres',
-      host: 'localhost',
-      port: 5432,
-      username: 'postgres',
-      password: 'admin',
-      database: 'postgres',
-      entities: [__dirname + '/../**/*.entity{.ts,.js}'],
-      synchronize: true, // This needs to be disabled when we set up the real repo and be replaced with migrations!
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => ({
+        type: 'postgres',
+        url: configService.get('DATABASE_URL'),
+        entities: [__dirname + '/../**/*.entity{.ts,.js}'],
+        synchronize: configService.get('NODE_ENV') !== 'production',
+      }),
+      inject: [ConfigService],
     }),
     InventoryModule,
     UserModule,


### PR DESCRIPTION
Rather than building/referencing a local db, use a hosted db.